### PR TITLE
Add parsing proxy section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 **/bin/
 **/.vscode/
+**/.idea/


### PR DESCRIPTION
Zabbix stats now returns a section with proxy servers, added this logic

```
zabbix_proxy_cert{name="proxy1",version="undefined"} 0
zabbix_proxy_cert{name="proxy2",version="undefined"} 1
zabbix_proxy_compatibility{name="proxy1",version="undefined"} 0
zabbix_proxy_compatibility{name="proxy2",version="undefined"} 0
zabbix_proxy_compression{name="proxy1",version="undefined"} 1
zabbix_proxy_compression{name="proxy2",version="undefined"} 1
zabbix_proxy_hosts{name="proxy1",version="undefined"} 1
zabbix_proxy_hosts{name="proxy2",version="undefined"} 0
zabbix_proxy_items{name="proxy1",version="undefined"} 0
zabbix_proxy_items{name="proxy2",version="undefined"} 0
zabbix_proxy_last_seen{name="proxy1",version="undefined"} -1
zabbix_proxy_last_seen{name="proxy2t",version="undefined"} -1
zabbix_proxy_passive{name="proxy1",version="undefined"} 0
zabbix_proxy_passive{name="proxy2",version="undefined"} 0
zabbix_proxy_psk{name="proxy1",version="undefined"} 0
zabbix_proxy_psk{name="proxy2",version="undefined"} 0
zabbix_proxy_requiredperformance{name="proxy1",version="undefined"} 4.211944
zabbix_proxy_requiredperformance{name="proxy2",version="undefined"} 0
zabbix_proxy_unencrypted{name="proxy1",version="undefined"} 1
zabbix_proxy_unencrypted{name="proxy2",version="undefined"} 1
```